### PR TITLE
fix: prevent mouse cursor reset when unhiding

### DIFF
--- a/godot/scripts/player/camera_controller.gd
+++ b/godot/scripts/player/camera_controller.gd
@@ -1,0 +1,12 @@
+extends Camera3D
+
+var _last_mouse_pos: Vector2
+
+func _input(event):
+    if event.is_action_pressed("drag_camera"):
+        _last_mouse_pos = get_viewport().get_mouse_position()
+        Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
+    elif event.is_action_released("drag_camera"):
+        Input.mouse_mode = Input.MOUSE_MODE_VISIBLE
+        # Restore mouse position after unhiding to prevent reset
+        get_viewport().warp_mouse(_last_mouse_pos)


### PR DESCRIPTION
Fixes #254

This fix ensures that the mouse cursor's screen position is captured before setting the mouse mode to captured and restored using `warp_mouse` when the mode is set back to visible. This prevents the cursor from jumping to the center of the viewport or an unintended position when unhiding after camera dragging.

---
*This PR was autonomously generated by [Pangea 3](https://github.com/sebmuehlbauer) — an AI-powered development system.*