### PR TITLE
Fix: Mouse position resetting after unhiding (#254)

### DIFF
--- a/godot/scripts/camera/states/state_camera_animated.gd
+++ b/godot/scripts/camera/states/state_camera_animated.gd
@@ -9,7 +9,11 @@ var input: InputManager:
     get: return Globals.input
 
 
+var last_mouse_pos: Vector2
+
 func enter() -> void:
+    # Store mouse position before any state changes
+    last_mouse_pos = DisplayServer.mouse_get_position()
     next_state = StateCameraAnimated
 
 
@@ -39,6 +43,9 @@ func process() -> void:
     elif camera.menu_is_open:
         if Input.mouse_mode == Input.MOUSE_MODE_CAPTURED:
             Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+        # Restore mouse position to prevent jumping
+        if last_mouse_pos != Vector2.ZERO:
+            DisplayServer.mouse_set_position(last_mouse_pos)
 
 
 func exit() -> void:

--- a/godot/scripts/camera/states/state_camera_follow.gd
+++ b/godot/scripts/camera/states/state_camera_follow.gd
@@ -11,7 +11,11 @@ var input: InputManager:
     get: return Globals.input
 
 
+var last_mouse_pos: Vector2
+
 func enter() -> void:
+    # Store mouse position before any state changes
+    last_mouse_pos = DisplayServer.mouse_get_position()
     next_state = StateCameraFollow
 
 
@@ -42,6 +46,9 @@ func process() -> void:
     elif camera.menu_is_open:
         if Input.mouse_mode == Input.MOUSE_MODE_CAPTURED:
             Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+        # Restore mouse position to prevent jumping
+        if last_mouse_pos != Vector2.ZERO:
+            DisplayServer.mouse_set_position(last_mouse_pos)
 
 
 func exit() -> void:

--- a/godot/scripts/camera/states/state_camera_free.gd
+++ b/godot/scripts/camera/states/state_camera_free.gd
@@ -6,7 +6,11 @@ var input: InputManager:
     get: return Globals.input
 
 
+var last_mouse_pos: Vector2
+
 func enter() -> void:
+    # Store mouse position before any state changes
+    last_mouse_pos = DisplayServer.mouse_get_position()
     next_state = StateCameraFree
 
 
@@ -34,6 +38,9 @@ func process() -> void:
     elif camera.menu_is_open:
         if Input.mouse_mode == Input.MOUSE_MODE_CAPTURED:
             Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+        # Restore mouse position to prevent jumping
+        if last_mouse_pos != Vector2.ZERO:
+            DisplayServer.mouse_set_position(last_mouse_pos)
 
 
 func exit() -> void:


### PR DESCRIPTION
This PR fixes the mouse cursor position resetting whenever it is unhidden (e.g., after dragging the camera).

## Changes:
- Store last mouse position before camera state changes
- Restore mouse position when switching to visible mode
- Applied to all three camera states: follow, free, and animated

## Testing:
- Drag camera to rotate (mouse becomes hidden/captured)
- Release to stop rotating
- Mouse should appear at last position instead of resetting

Fixes #254