### PR TITLE
fix: preserve mouse position after unhiding cursor

### DIFF
--- a/godot/scripts/input/input_manager.gd
+++ b/godot/scripts/input/input_manager.gd
@@ -112,11 +112,20 @@ func _unhandled_input(event: InputEvent) -> void:
             action_map[action].emit()
 
 
+var _last_mouse_pos := Vector2.ZERO
+
 func set_mouse_capture(capture: bool) -> void:
     capture_mouse_on_click = capture
     # Ensure the mouse is visible and not actively captured
     if not capture_mouse_on_click:
         Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+        # Restore mouse position after unhiding
+        if _last_mouse_pos != Vector2.ZERO:
+            Input.warp_mouse(_last_mouse_pos)
+            _last_mouse_pos = Vector2.ZERO
+    else:
+        # Save mouse position before hiding
+        _last_mouse_pos = Input.get_last_mouse_position()
 
 
 func _on_allow_character_control(allow: bool) -> void:


### PR DESCRIPTION
Fixes #254

## Problem
Mouse cursor position resets when unhidden (after dragging the camera).

## Solution
Save mouse position before hiding and restore it after unhiding using `Input.warp_mouse()`.

## Changes
- Added `_last_mouse_pos` variable to store cursor position
- Save position in `set_mouse_capture(true)` before hiding
- Restore position in `set_mouse_capture(false)` after unhiding
- Reset saved position after restoring to avoid stale data