### PR TITLE
Add status effect spell trait

### DIFF
--- a/godot/scripts/bft.gd
+++ b/godot/scripts/bft.gd
@@ -10,6 +10,8 @@ enum ID {
     TRAIT_DAMAGE_TARGET,
     TRAIT_SPAWN_ENTITY,
     TRAIT_SHOOT_PROJECTILE,
+    TRAIT_DAMAGE_CASTER,
+    TRAIT_APPLY_STATUS,
 }
 
 const id_to_type: Dictionary[ID, Resource] = {
@@ -25,10 +27,14 @@ const id_to_type: Dictionary[ID, Resource] = {
         "res://scripts/messages/msg_cast_req.gd"),
     ID.TRAIT_DAMAGE_TARGET: preload(
         "res://scripts/spells/traits/damage_target.gd"),
+    ID.TRAIT_DAMAGE_CASTER: preload(
+        "res://scripts/spells/traits/damage_caster.gd"),
     ID.TRAIT_SPAWN_ENTITY: preload(
         "res://scripts/spells/traits/spawn_entity.gd"),
     ID.TRAIT_SHOOT_PROJECTILE: preload(
         "res://scripts/spells/traits/trait_shoot_projectile.gd"),
+    ID.TRAIT_APPLY_STATUS: preload(
+        "res://scripts/spells/traits/apply_status.gd"),
 }
 
 

--- a/godot/scripts/spells/spell.gd
+++ b/godot/scripts/spells/spell.gd
@@ -9,6 +9,7 @@ signal cast_started
 @export_category("Runtime Values")
 @export var traits: Array[Trait] = []
 @export var caster: Entity
+@export var target_override: Entity
 @export var cast_cancel_token: String
 
 @onready var router := Globals.msg_router
@@ -20,6 +21,14 @@ var icon: Texture2D:
 
 var id := "":
     get: return data.id
+
+var target_entity: Entity:
+    get:
+        if is_instance_valid(target_override):
+            return target_override
+        if is_instance_valid(caster):
+            return caster.target
+        return null
 
 var is_castable: bool:
     get: return timer.time_left <= 0

--- a/godot/scripts/spells/status_data.gd
+++ b/godot/scripts/spells/status_data.gd
@@ -1,17 +1,29 @@
-class_name status_data extends Resource
+class_name StatusData extends Resource
 
 @export var id := ""
 @export var spell: SpellData
-@export var time := 1.0
-@export var max_charges := 1
+@export var expiration_time := 1.0
+@export var tick_rate := 1.0
+@export var max_stacks := 1
+
+
+func get_status_id() -> String:
+    if not id.is_empty():
+        return id
+    if spell and not spell.id.is_empty():
+        return spell.id
+    return "status"
 
 
 func serialize() -> Dictionary:
     var data := {}
     
     data["id"] = id
-    data["time"] = time
-    data["max_charges"] = max_charges
+    data["expiration_time"] = expiration_time
+    data["tick_rate"] = tick_rate
+    data["max_stacks"] = max_stacks
+    data["time"] = expiration_time
+    data["max_charges"] = max_stacks
 
     if spell:
         data["spell_data"] = spell.serialize()
@@ -23,7 +35,14 @@ func serialize() -> Dictionary:
 
 func deserialize(data: Dictionary) -> void:
     id = data.get("id", id)
-    time = data.get("time", time)
-    max_charges = data.get("max_charges", max_charges)
+    expiration_time = data.get("expiration_time", data.get("time", expiration_time))
+    tick_rate = data.get("tick_rate", tick_rate)
+    max_stacks = data.get("max_stacks", data.get("max_charges", max_stacks))
+
     var spell_dict = data.get("spell_data")
-    spell.deserialize(spell_dict)
+    if spell_dict and spell_dict is Dictionary:
+        if not spell:
+            spell = SpellData.new()
+        spell.deserialize(spell_dict)
+    elif spell_dict == null:
+        spell = null

--- a/godot/scripts/spells/status_effect.gd
+++ b/godot/scripts/spells/status_effect.gd
@@ -1,0 +1,102 @@
+class_name StatusEffect extends Node
+
+var data: StatusData
+var target: Entity
+var source: Entity
+var stacks := 0
+
+var expiration_timer := Timer.new()
+var tick_timer := Timer.new()
+
+
+static func node_name_for(status_id: String) -> String:
+    var cleaned := status_id.strip_edges()
+    if cleaned.is_empty():
+        cleaned = "status"
+    cleaned = cleaned.replace("/", "_").replace(":", "_").replace(" ", "_")
+    return "StatusEffect_%s" % cleaned
+
+
+func setup(status_data: StatusData, target_entity: Entity, source_entity: Entity) -> void:
+    data = status_data
+    target = target_entity
+    source = source_entity
+
+    expiration_timer.one_shot = true
+    expiration_timer.timeout.connect(_on_expired)
+    add_child(expiration_timer)
+
+    tick_timer.one_shot = false
+    tick_timer.timeout.connect(_on_tick)
+    add_child(tick_timer)
+
+    add_stack(source_entity)
+    _start_ticking()
+
+
+func add_stack(source_entity: Entity) -> void:
+    if is_instance_valid(source_entity):
+        source = source_entity
+
+    var stack_limit := max(1, data.max_stacks)
+    stacks = min(stacks + 1, stack_limit)
+    _refresh_expiration()
+
+
+func _start_ticking() -> void:
+    if data == null or data.tick_rate <= 0.0:
+        return
+
+    tick_timer.wait_time = data.tick_rate
+    tick_timer.start()
+
+
+func _refresh_expiration() -> void:
+    if data == null or data.expiration_time <= 0.0:
+        expiration_timer.stop()
+        return
+
+    expiration_timer.wait_time = data.expiration_time
+    expiration_timer.start()
+
+
+func _on_tick() -> void:
+    if not _has_valid_context():
+        queue_free()
+        return
+
+    for _stack_index in range(stacks):
+        _cast_status_spell()
+
+
+func _cast_status_spell() -> void:
+    if data.spell == null:
+        return
+
+    var status_spell := Spell.new()
+    status_spell.setup(data.spell, source if is_instance_valid(source) else target)
+    status_spell.target_override = target
+
+    for trait_data in data.spell.traits:
+        if not trait_data:
+            continue
+
+        var trait_script := trait_data.trait_script
+        if not trait_script:
+            continue
+
+        var trait: Trait = trait_script.new()
+        trait.setup(trait_data, status_spell)
+        add_child(trait)
+        trait.cast()
+        trait.queue_free()
+
+    status_spell.free()
+
+
+func _has_valid_context() -> bool:
+    return data != null and is_instance_valid(target)
+
+
+func _on_expired() -> void:
+    queue_free()

--- a/godot/scripts/spells/traits/apply_status.gd
+++ b/godot/scripts/spells/traits/apply_status.gd
@@ -1,0 +1,26 @@
+class_name ApplyStatus extends Trait
+
+
+func cast() -> void:
+    if data.apply_status == null:
+        return
+
+    var target := spell.target_entity
+    if not is_instance_valid(target):
+        target = spell.caster
+
+    if not is_instance_valid(target):
+        return
+
+    var status_id := data.apply_status.get_status_id()
+    var node_name := StatusEffect.node_name_for(status_id)
+    var existing := target.get_node_or_null(node_name)
+
+    if existing != null and existing is StatusEffect:
+        existing.add_stack(spell.caster)
+        return
+
+    var effect := StatusEffect.new()
+    effect.name = node_name
+    target.add_child(effect)
+    effect.setup(data.apply_status, target, spell.caster)

--- a/godot/scripts/spells/traits/damage_caster.gd
+++ b/godot/scripts/spells/traits/damage_caster.gd
@@ -1,9 +1,6 @@
 class_name DamageCaster extends Trait
 
-@export var damage := 10.0
-
-
 func cast() -> void:
     var health = spell.caster.health
     if health:
-        health.current -= damage 
+        health.current -= data.damage

--- a/godot/scripts/spells/traits/damage_target.gd
+++ b/godot/scripts/spells/traits/damage_target.gd
@@ -1,13 +1,8 @@
 class_name DamageTarget extends Trait
 
 @onready var signals := Globals.signal_bus
-@onready var entities := Globals.entities
-
-var caster: Entity
-
-
 func cast() -> void:
-    var target := entities.find(spell.caster.target_id)
+    var target := spell.target_entity
     if not target:
         lg.debug("No target")
         return

--- a/godot/scripts/spells/traits/trait_data.gd
+++ b/godot/scripts/spells/traits/trait_data.gd
@@ -11,7 +11,7 @@ class_name TraitData extends Resource
 @export var summon_entity:  PackedScene
 @export var entity_data:    EntityData
 @export_category("Apply Effects")
-@export var apply_status: SpellData
+@export var apply_status: StatusData
 
 var trait_script: GDScript = Trait:
     get: return BFT.get_type(trait_type)
@@ -44,8 +44,7 @@ func deserialize(data: Dictionary) -> void:
     damage  = data.get("damage", damage)
     healing = data.get("healing", healing)
 
-    var type_of_trait: BFT.ID = data.get("type", BFT.ID.UNKNOWN)
-    trait_script = BFT.get_type(type_of_trait)
+    trait_type = data.get("type", BFT.ID.UNKNOWN)
     print_debug("trait script is ", trait_script)
 
     var scene_path: String = data.get("summon_entity", "")
@@ -65,7 +64,14 @@ func deserialize(data: Dictionary) -> void:
     var status_dict = data.get("apply_status")
     if status_dict and status_dict is Dictionary:
         if not apply_status:
-            apply_status = SpellData.new()
-        apply_status.deserialize(status_dict)
+            apply_status = StatusData.new()
+
+        if status_dict.has("spell_data"):
+            apply_status.deserialize(status_dict)
+        else:
+            var legacy_spell := SpellData.new()
+            legacy_spell.deserialize(status_dict)
+            apply_status.id = legacy_spell.id
+            apply_status.spell = legacy_spell
     elif status_dict == null:
         apply_status = null


### PR DESCRIPTION
## Summary
- add an `ApplyStatus` trait and `StatusData` config for status spell, stack limit, expiration time, and tick interval
- add a `StatusEffect` runtime node that refreshes duration, caps stacks, and recasts the configured status spell on each tick
- preserve existing numeric trait IDs while registering new status/damage-caster traits, and let target-damage traits use a stored target override for recasts

Closes #274

## Validation
- `git diff --check`

Godot is not installed in this environment. I attempted to run a Godot CI Docker image for an import check, but the image pull stalled before completion, so runtime/editor validation still needs to happen in a Godot 4.5 environment.
